### PR TITLE
Updated links for the footer, to show the new Twitter and Linked accounts

### DIFF
--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -53,7 +53,7 @@ export default {
     target: '_blank',
   },
   twitter: {
-    to: 'https://twitter.com/CNNordics',
+    to: 'https://twitter.com/kcd_dk',
     target: '_blank',
   },
   googlemaps: {

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -49,7 +49,7 @@ export default {
 
   // Social-links
   linkedin: {
-    to: 'https://www.linkedin.com/company/cloud-native-nordics',
+    to: 'https://www.linkedin.com/company/kubernetes-community-days-denmark',
     target: '_blank',
   },
   twitter: {


### PR DESCRIPTION
Since we got a new Twitter and Linkedin page, i have changed the url's for both in the footer, to lead to the correct accounts. 
