### PR TITLE
changed early-bird workind on page to just tickets on sale

### DIFF
--- a/src/components/pages/home/welcome/welcome.jsx
+++ b/src/components/pages/home/welcome/welcome.jsx
@@ -4,7 +4,7 @@ const Welcome = () => (
   <section className="safe-paddings bg-white py-40 md:py-24 sm:py-16">
     <div className="container-md">
       <div className="text-2xl text-primary-1 sm:text-lg">
-        <p className="mt-3 text-center text-4xl font-bold leading-tight pb-8">Early-bird Tickets on Sale Now!</p>
+        <p className="mt-3 text-center text-4xl font-bold leading-tight pb-8">Tickets sale is open!</p>
         <hr className="pb-8" />
         <p>
           <span className="font-bold">Kubernetes Community Days</span> (KCDs) are global,


### PR DESCRIPTION
Changed to wording on the front page, from "early bird" to just "Tickets on sale" since early bird is sold out.